### PR TITLE
Update grunt-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-imageoptim": "^1.4.1",
-    "grunt-sass": "^0.14.0"
+    "grunt-sass": "^1.1.0"
   }
 }


### PR DESCRIPTION
The old version of `node-sass` (used by `grunt-sass`) was not compatible with OS X El Capitan. Tested and this does work.