### PR TITLE
Allows to open links in a new tab with a middle click

### DIFF
--- a/scripts/cds.js
+++ b/scripts/cds.js
@@ -294,8 +294,9 @@ export function init () {
     }
 
     _onClick (evt) {
-      // If this is a ctrl-click / cmd-click, don't do anything.
-      if (evt.metaKey || evt.ctrlKey) {
+      // If this is a ctrl-click / cmd-click or any other than the main
+      // mouse button, don't do anything.
+      if (evt.metaKey || evt.ctrlKey || evt.button !== 0) {
         return;
       }
 


### PR DESCRIPTION
Fixes #20.

It seems just excluding middle mouse clicks is not enough. As it is now Firefox does even prevent showing the context menu on right click and does the navigation instead.

For me the best solution seems to be to filter only for left (main button) clicks.
