### PR TITLE
 Change live-info__description overflow-y to auto

### DIFF
--- a/sass/live.scss
+++ b/sass/live.scss
@@ -64,7 +64,7 @@
   line-height: 1.6;
   margin: $baseline 0 0 0;
   max-height: $baseline * 19;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .live-coming-up {


### PR DESCRIPTION
Remove ugly scrollbar if not needed. overflow-y `auto` instead of `scroll` on live-info__description.

A little thing on such a beautiful site that annoyed me so much that I had to open a pull request. :'D

But great work with that website!
Hope I could design as good as you do.