### PR TITLE
Fix failed navigations

### DIFF
--- a/scripts/cds.js
+++ b/scripts/cds.js
@@ -157,8 +157,11 @@ export function init () {
 
     _hideAreas () {
       return new Promise(function (resolve, reject) {
-        document.body.classList.add('hide-areas');
+        if (document.body.classList.contains('hide-areas')) {
+          resolve();
+        }
         this._mastheadGraphic.addEventListener('transitionend', resolve);
+        document.body.classList.add('hide-areas');
       }.bind(this));
     }
 
@@ -392,4 +395,3 @@ export function init () {
   new CDS();
   /* eslint-enable no-new */
 }
-

--- a/scripts/cds.js
+++ b/scripts/cds.js
@@ -159,6 +159,7 @@ export function init () {
       return new Promise(function (resolve, reject) {
         if (document.body.classList.contains('hide-areas')) {
           resolve();
+          return;
         }
         this._mastheadGraphic.addEventListener('transitionend', resolve);
         document.body.classList.add('hide-areas');


### PR DESCRIPTION
Should close https://github.com/GoogleChrome/devsummit/issues/59 @surma

The `if` check should prevent us from playing the waiting game with a transition that will never go. Let me know if this is good Surma. I also changed the `transitionend` event listener to be added right before we mutate any classes; that order seemed to make sense in my head.

----

When I pulled the code down, the file had two trailing new lines (though GH only shows 1). Atom, in its politeness, removed **one** of them. If you pull the code down and check the file there should still be one there though GH doesn't seem to show it.