### PR TITLE
add eslint and eslint-config-google to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "babel-cli": "^6.16.0",
     "babel-preset-babili": "0.0.3",
     "clean-css": "^3.4.19",
+    "eslint": "^3.12.2",
+    "eslint-config-google": "^0.7.1",
     "imageoptim-cli": "^1.14.8",
     "mkdirp": "^0.5.1",
     "node-sass": "^3.10.0",


### PR DESCRIPTION
- makes trying out the repo easier - example: prevents vscode from displaying banner `must install eslint-config-google`
- resolves peer depenedency issues that can arrise when having eslint installed globally
  and running `npm i eslint-config-google -g`