### PR TITLE
Moving to Rollup's unified file emit stuff

### DIFF
--- a/lib/html-css-plugin.js
+++ b/lib/html-css-plugin.js
@@ -66,7 +66,6 @@ const defaultOptions = {
 };
 
 export default function htmlCSSPlugin(userOptions = {}) {
-  let assetCache;
   let nonJSChunks;
   const options = { ...defaultOptions, ...userOptions };
 
@@ -88,29 +87,27 @@ export default function htmlCSSPlugin(userOptions = {}) {
         ) {
           // We get css and html from .build-tmp, js comes from src.
           const parentDir = targetPath.endsWith('.js') ? 'src' : '.build-tmp';
-          const id = rollup.emitChunk(join(parentDir, targetPath), {
+          const id = rollup.emitFile({
+            type: 'chunk',
             // Remove extension from name.
             // Otherwise, Rollup seems to branch on html/css vs js extensions.
             // This way we can normalise it & add it again in generateBundle.
             name: targetPath.replace(/\.[^\.]+$/, ''),
+            id: join(parentDir, targetPath),
           });
 
           // This will be replaced with the real URL in generateBundle.
-          return `${importMetaStart}import.meta.ROLLUP_CHUNK_URL_${id}${importMetaEnd}`;
+          return `${importMetaStart}import.meta.ROLLUP_FILE_URL_${id}${importMetaEnd}`;
         }
 
-        // This lets us dedupe assets.
-        // We don't need this once https://github.com/rollup/rollup/issues/2959 lands.
-        if (!assetCache.has(targetPath)) {
-          const source = getAsset(targetPath);
-          const id = rollup.emitAsset(targetPath, source);
-          assetCache.set(targetPath, id);
-        }
+        const id = rollup.emitFile({
+          type: 'asset',
+          name: targetPath,
+          source: getAsset(targetPath),
+        });
 
         // This will be replaced with the real URL in generateBundle.
-        return `${importMetaStart}import.meta.ROLLUP_ASSET_URL_${assetCache.get(
-          targetPath,
-        )}${importMetaEnd}`;
+        return `${importMetaStart}import.meta.ROLLUP_FILE_URL_${id}${importMetaEnd}`;
       },
     );
 
@@ -120,7 +117,6 @@ export default function htmlCSSPlugin(userOptions = {}) {
   return {
     name: 'html-css-plugin',
     async buildStart() {
-      assetCache = new Map();
       nonJSChunks = new Set();
     },
     load(id) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11493,26 +11493,25 @@
       }
     },
     "rollup": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.17.0.tgz",
-      "integrity": "sha512-k/j1m0NIsI4SYgCJR4MWPstGJOWfJyd6gycKoMhyoKPVXxm+L49XtbUwZyFsrSU2YXsOkM4u1ll9CS/ZgJBUpw==",
+      "version": "github:rollup/rollup#6f6d277755b0e02af48c0b1945dd61f2a4d9ec5f",
+      "from": "github:rollup/rollup#unified-file-emission-api",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.6.2",
+        "@types/node": "^12.6.3",
         "acorn": "^6.2.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
-          "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==",
+          "version": "12.6.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+          "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
           "dev": true
         },
         "acorn": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-          "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettier": "1.18.2",
     "pretty-quick": "^1.11.1",
     "require-from-string": "^2.0.2",
-    "rollup": "^1.17.0",
+    "rollup": "github:rollup/rollup#unified-file-emission-api",
     "rollup-plugin-terser": "^5.1.1"
   },
   "husky": {


### PR DESCRIPTION
https://github.com/rollup/rollup/pull/2999

Seems to work.

Once https://github.com/rollup/rollup/issues/2823 is solved we'll switch to a system where our HTML files are assets with fixed file names. And our CSS files are named assets. As in, remove all the chunk hacks.