### PR TITLE
Title case for CoC page

### DIFF
--- a/src/coc.md
+++ b/src/coc.md
@@ -1,6 +1,6 @@
 ---
 layout: layouts/content/index.njk
-title: community guidelines
+title: Community guidelines
 ---
 
 # Google Event Community Guidelines & Anti-Harrassment Policy


### PR DESCRIPTION
Although it displays lowercase in the page, it should be title case for the `<title>`