### PR TITLE
Adding date formatter that doesn't use the timezone

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -91,7 +91,12 @@ module.exports = function(eleventyConfig) {
     return str.toLowerCase().replace(/\s/g, '-');
   });
 
-  /** Format a date in the timezone of the conference */
+  /** Format a date/timestamp */
+  eleventyConfig.addShortcode('date', (timestamp, format) => {
+    return date.format(new Date(timestamp.valueOf()), format);
+  });
+
+  /** Format a date/timestamp in the timezone of the conference */
   eleventyConfig.addShortcode('confDate', (timestamp, format) => {
     const offsetTime = new Date(timestamp.valueOf() + utcOffset);
     return date.format(offsetTime, format);

--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ In templates and CSS, references assets via `confboxAsset('/path/to/asset.jpg')`
 
 Assets ending `.js` will be bundled together using Rollup.
 
-## `{% confDate date, format %}`
+## `{% date date, format %}`
 
-This will take a `date` and format it for the timezone of the conference (as set in `/confbox.config.js`).
+This will take a `date` and format it. This will always use the UTC timezone. If you're formatting for human eyes, use `{% confDate date, format %}` instead.
 
 - `date` - The date to display. This can be a `Date` object or a timestamp.
 - `format` - A formatting string as used by [date-and-time](https://www.npmjs.com/package/date-and-time#formatdateobj-formatstring-utc).
+
+## `{% confDate date, format %}`
+
+As `{% date date, format %}`, but in the timezone of the conference (as set in `/confbox.config.js`).
 
 ```njk
 <p>The conference starts {% confDate conf.start, 'MMMM DD' %}</p>

--- a/src/index.njk
+++ b/src/index.njk
@@ -10,8 +10,8 @@ description: Connect with Chrome engineers and other leading developers for an e
       "@context": "https://schema.org",
       "@type": "Event",
       "name": "{{conf.conferenceName}}",
-      "startDate": "{% confDate conf.start, 'YYYY-MM-DDTHH:mm' %}",
-      "endDate": "{% confDate conf.end, 'YYYY-MM-DDTHH:mm' %}",
+      "startDate": "{% confDate conf.start, 'YYYY-MM-DD' %}",
+      "endDate": "{% confDate conf.end, 'YYYY-MM-DD' %}",
       "location": {
         "@type": "Place",
         "name": "{{conf.venue.name}}",


### PR DESCRIPTION
I didn't use it in the end, but is it worth keeping?

Also making the structured data less specific, which will hopefully(?) fix the off-by-one date in search results.