### PR TITLE
Shorter descriptions in the schedule

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,11 +32,7 @@ function buildScheduleData(sessions, speakers) {
       topics: session.data.topics,
       session: true,
       fileSlug: session.fileSlug,
-      // Accessing the templateContent right now throws an error
-      // but it can be accessed once templates are being processed.
-      get body() {
-        return session.templateContent;
-      },
+      body: session.data.description,
     })),
     ...extraSchedule.map(obj => ({ ...obj })),
   ].map(item => {

--- a/src/schedule/script/create-schedule.js
+++ b/src/schedule/script/create-schedule.js
@@ -1,5 +1,5 @@
 const { monthsShort } = require('../../script/date');
-const { html, safe } = require('../../script/escape-html');
+const { html } = require('../../script/escape-html');
 
 module.exports = function createScheduleHtml(
   items,
@@ -29,23 +29,23 @@ module.exports = function createScheduleHtml(
   }
 
   return html`
-    <section class="${classNameMap['schedule']}">
+    <section class="${classNameMap.schedule}">
       ${days.map(
         ({ date, month, items }, dayNum) => html`
-          <div class="${classNameMap['day']}">
-            <h1 class="${classNameMap['date']}">
-              <span class="${classNameMap['dateName']}"
+          <div class="${classNameMap.day}">
+            <h1 class="${classNameMap.date}">
+              <span class="${classNameMap.dateName}"
                 >${monthsShort[month]}</span
               >
-              <span class="${classNameMap['dateNumber']}">${date}</span>
+              <span class="${classNameMap.dateNumber}">${date}</span>
             </h1>
-            <div class="${classNameMap['dayTitle']}">
+            <div class="${classNameMap.dayTitle}">
               Day
-              <span class="${classNameMap['dayNumber']}">${dayNum + 1}</span>
+              <span class="${classNameMap.dayNumber}">${dayNum + 1}</span>
             </div>
 
             <div
-              class="${`${classNameMap['timeLine']} ${classNameMap['dayGap']}`}"
+              class="${`${classNameMap.timeLine} ${classNameMap.dayGap}`}"
             ></div>
 
             ${items.map(item => {
@@ -54,13 +54,13 @@ module.exports = function createScheduleHtml(
               const minutes = sessionDate.getUTCMinutes();
 
               return html`
-                <div class="${classNameMap['timeLine']}">
-                  <div class="${classNameMap['timeLineContent']}">
+                <div class="${classNameMap.timeLine}">
+                  <div class="${classNameMap.timeLineContent}">
                     ${item.icon
                       ? html`
-                          <div class="${classNameMap['iconBubble']}">
+                          <div class="${classNameMap.iconBubble}">
                             <img
-                              class="${classNameMap['icon']}"
+                              class="${classNameMap.icon}"
                               src="${item.icon}"
                               alt=""
                             />
@@ -68,8 +68,8 @@ module.exports = function createScheduleHtml(
                         `
                       : item.speakers
                       ? html`
-                          <div class="${classNameMap['iconBubble']}">
-                            <div class="${classNameMap['avatars']}">
+                          <div class="${classNameMap.iconBubble}">
+                            <div class="${classNameMap.avatars}">
                               ${item.speakers.map(
                                 speaker => html`
                                   <img
@@ -82,37 +82,38 @@ module.exports = function createScheduleHtml(
                           </div>
                         `
                       : html`
-                          <div class="${classNameMap['dot']}"></div>
+                          <div class="${classNameMap.dot}"></div>
                         `}
-                    <h2 class="${classNameMap['time']}">
+                    <h2 class="${classNameMap.time}">
                       <time>
                         ${hours % 12 || 12}${minutes ? ':' + minutes : ''}
-                        <span class="${classNameMap['amPm']}"
+                        <span class="${classNameMap.amPm}"
                           >${hours < 12 ? 'am' : 'pm'}</span
                         >
                       </time>
                     </h2>
                   </div>
                 </div>
-                <div class="${classNameMap['item']}">
+                <div class="${classNameMap.item}">
                   ${item.body
                     ? html`
-                        <a
-                          class="${classNameMap['sessionLink']}"
-                          href="${confPath}sessions/${item.fileSlug}"
-                        >
-                          <div class="${classNameMap['sessionItem']}">
-                            <h3 class="${classNameMap['sessionItemTitle']}">
-                              ${item.title}
-                            </h3>
-                            <div>${safe(item.body)}</div>
+                        <div class="${classNameMap.sessionItem}">
+                          <h3 class="${classNameMap.sessionItemTitle}">
+                            <a
+                              class="${classNameMap.sessionLink}"
+                              href="${confPath}sessions/${item.fileSlug}"
+                              >${item.title}</a
+                            >
+                          </h3>
+                          <div><p>${item.body}</p></div>
+                          <div class="${classNameMap.meta}">
                             ${item.topics
                               ? html`
-                                  <ul class="${classNameMap['topicList']}">
+                                  <ul class="${classNameMap.topicList}">
                                     ${item.topics.map(
                                       topic => html`
                                         <li>
-                                          <div class="${classNameMap['topic']}">
+                                          <div class="${classNameMap.topic}">
                                             ${topic}
                                           </div>
                                         </li>
@@ -121,14 +122,17 @@ module.exports = function createScheduleHtml(
                                   </ul>
                                 `
                               : ''}
+                            <a href="${confPath}sessions/${item.fileSlug}"
+                              >Read more</a
+                            >
                           </div>
-                        </a>
+                        </div>
                       `
                     : html`
                         <h3
-                          class="${`${classNameMap['basicItemTitle']} ${
+                          class="${`${classNameMap.basicItemTitle} ${
                             !item.icon && !item.speakers
-                              ? classNameMap['basicItemTitleDotAlign']
+                              ? classNameMap.basicItemTitleDotAlign
                               : ''
                           }`}"
                         >
@@ -136,11 +140,11 @@ module.exports = function createScheduleHtml(
                         </h3>
                       `}
                 </div>
-                <div class="${classNameMap['rowGap']}"></div>
+                <div class="${classNameMap.rowGap}"></div>
               `;
             })}
 
-            <div class="${classNameMap['end']}"></div>
+            <div class="${classNameMap.end}"></div>
           </div>
         `,
       )}

--- a/src/schedule/style.css
+++ b/src/schedule/style.css
@@ -188,6 +188,7 @@
 
   @media (min-width: 720px) {
     font-size: 0.7rem;
+    margin-top: 0.6rem;
   }
 }
 

--- a/src/schedule/style.css
+++ b/src/schedule/style.css
@@ -289,6 +289,12 @@
   }
 }
 
+.meta {
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  align-items: center;
+}
+
 .topic {
   font-size: 0.9rem;
   border: 1px solid var(--lessdarkoffwhite);

--- a/src/sessions/adaptive-loading.md
+++ b/src/sessions/adaptive-loading.md
@@ -8,6 +8,7 @@ speakers:
   - nate-schloss
 start: 2019/11/11 14:35
 end: 2019/11/11 15:10
+description: Today, developers often build components and routes for a single baseline. However, the environment conditions users are in are often much more nuanced…
 ---
 
 Today, developers often build components and routes for a single baseline ("mobile", "desktop"). However, the environment conditions users are in are often much more nuanced. They may be on a device with a slow CPU, on a network that varies from slow to fast, may be memory or even battery constrained. How can we use signals available to the Web Platform to serve our resources the experience most likely to meet their needs at a point in time? Adaptive Loading explores this problem space.

--- a/src/sessions/advancing-the-web-framework-ecosystem.md
+++ b/src/sessions/advancing-the-web-framework-ecosystem.md
@@ -8,7 +8,7 @@ speakers:
   - houssein-djirdeh
 start: 2019/11/12 11:10
 end: 2019/11/12 11:45
-description: This talk covers the team's work with Next.js on build and runtime optimizations, what's next in the pipeline, and our plans for other parts of the ecosystem.
+description: This talk covers the team's work with Next.js on build and runtime optimizations, what's next in the pipeline, and our plans for other parts of the ecosystem…
 ---
 
 Chrome is now an active contributor to the frameworks web ecosystem to improve tools used by developers around the world, including infrastructure and tooling to produce and maintain performant sites as they continue to grow and change.

--- a/src/sessions/advancing-the-web-framework-ecosystem.md
+++ b/src/sessions/advancing-the-web-framework-ecosystem.md
@@ -8,6 +8,7 @@ speakers:
   - houssein-djirdeh
 start: 2019/11/12 11:10
 end: 2019/11/12 11:45
+description: This talk covers the team's work with Next.js on build and runtime optimizations, what's next in the pipeline, and our plans for other parts of the ecosystem.
 ---
 
 Chrome is now an active contributor to the frameworks web ecosystem to improve tools used by developers around the world, including infrastructure and tooling to produce and maintain performant sites as they continue to grow and change.

--- a/src/sessions/bridging-the-native-app-gap.md
+++ b/src/sessions/bridging-the-native-app-gap.md
@@ -7,6 +7,7 @@ speakers:
   - sam-richard
 start: 2019/11/11 17:25
 end: 2019/11/11 18:00
+description: The Web today is an incredibly powerful platform, but there's still a gap between what web apps can do and the capabilities of native apps. Web needs access to more powerful APIs…
 ---
 
 The Web today is an incredibly powerful platform, but there's still a gap between what web apps can do and the capabilities of native apps. Progressive Web Apps get us part of the way there, but to truly compete, the Web needs access to more powerful APIs, too. Well, good news! They're coming! From contact pickers to file system access to app badging and more, new APIs are on their way to expand what kinds of applications can be built on the Web.

--- a/src/sessions/chrome-extensions-tomorrow.md
+++ b/src/sessions/chrome-extensions-tomorrow.md
@@ -7,6 +7,7 @@ speakers:
   - simeon-vincent
 start: 2019/11/12 16:15
 end: 2019/11/12 16:50
+description: Chrome's extensions platform is undergoing a sea change. Nearly 6 years after the current manifest version was introduced, we are revving it again…
 ---
 
 Chrome's extensions platform is undergoing a sea change. Nearly 6 years after the current manifest version was introduced, we are revving it again. Manifest V3 rethinks several of the basics about how extensions work in order to make extensions more secure, performant, and privacy preserving.

--- a/src/sessions/how-to-make-your-content-shine-on-google-search.md
+++ b/src/sessions/how-to-make-your-content-shine-on-google-search.md
@@ -7,6 +7,7 @@ speakers:
   - martin-splitt
 start: 2019/11/12 16:50
 end: 2019/11/12 17:55
+description: In this session, we'll peek under the hood of Googlebot and talk about the implementation best practices, patterns, and available tools and debugging…
 ---
 
 With the new evergreen Googlebot, powered by the latest Chromium rendering engine, developers can leverage all the latest web technologies that optimize user experience and discoverability of their content.

--- a/src/sessions/html-isnt-done.md
+++ b/src/sessions/html-isnt-done.md
@@ -8,6 +8,7 @@ speakers:
   - greg-whitworth
 start: 2019/11/12 10:35
 end: 2019/11/12 11:10
+description: The web platform is now ready to pave those cow paths and extend HTML. And we need your help with these brand new shiny components…
 ---
 
 Let's go back in time a bit. Remember when word was out that we were going to get new HTML elements? I don't know about you, but I was so excited. After years of building the same tabset over and over, I thought, I'm done! Surely they'll see that tabs are one of the most common elements in _every design system ever_. Imagine my disappointment. `<aside>`, `<article>`, and their friends seemed so disconnected from the problems I was solving every day. I had no problem with them, I just didn't need them.

--- a/src/sessions/intent-to-explain.md
+++ b/src/sessions/intent-to-explain.md
@@ -8,6 +8,7 @@ speakers:
   - yoav-weiss
 start: 2019/11/12 10:00
 end: 2019/11/12 10:35
+description: How do those features come to be? Who decides which features should be worked on? What's the decision process that leads to shipping them? And how do web standards and other browser engines fit into all of this?
 ---
 
 Welcome to Chrome Dev Summit, where you'll hear about many new and shiny features coming soon to a Chromium-based browser near you!

--- a/src/sessions/intent-to-explain.md
+++ b/src/sessions/intent-to-explain.md
@@ -8,7 +8,7 @@ speakers:
   - yoav-weiss
 start: 2019/11/12 10:00
 end: 2019/11/12 10:35
-description: How do those features come to be? Who decides which features should be worked on? What's the decision process that leads to shipping them? And how do web standards and other browser engines fit into all of this?
+description: How do those features come to be? Who decides which features should be worked on? What's the decision process that leads to shipping them? And how do web standards and other browser engines fit into all of this…
 ---
 
 Welcome to Chrome Dev Summit, where you'll hear about many new and shiny features coming soon to a Chromium-based browser near you!

--- a/src/sessions/keynote.md
+++ b/src/sessions/keynote.md
@@ -8,6 +8,7 @@ speakers:
   - parisa-tabriz
 start: 2019/11/11 10:00
 end: 2019/11/11 11:00
+description: Celebrating every aspect of the web's diversity - the technologies, the tools and the people, and talk about how we're working together to Elevate the Web.
 ---
 
 The Web is an ecosystem with diversity galore: Web standards, multiple browsers, a huge number and variety of devices, and a plethora of tools and services available. This diversity is why the Web continues to evolve and we want developers to succeed through each phase of the Web's evolution. During the keynote, we'll celebrate every aspect of this diversity - the technologies, the tools and the people, and talk about how we're working together to Elevate the Web.

--- a/src/sessions/keynote.md
+++ b/src/sessions/keynote.md
@@ -8,7 +8,7 @@ speakers:
   - parisa-tabriz
 start: 2019/11/11 10:00
 end: 2019/11/11 11:00
-description: Celebrating every aspect of the web's diversity - the technologies, the tools and the people, and talk about how we're working together to Elevate the Web.
+description: Celebrating every aspect of the web's diversity - the technologies, the tools and the people, and talk about how we're working together to Elevate the Web…
 ---
 
 The Web is an ecosystem with diversity galore: Web standards, multiple browsers, a huge number and variety of devices, and a plethora of tools and services available. This diversity is why the Web continues to evolve and we want developers to succeed through each phase of the Web's evolution. During the keynote, we'll celebrate every aspect of this diversity - the technologies, the tools and the people, and talk about how we're working together to Elevate the Web.

--- a/src/sessions/make-loading-disappear-with-portals.md
+++ b/src/sessions/make-loading-disappear-with-portals.md
@@ -9,6 +9,7 @@ speakers:
   - yusuke-utsunomiya
 start: 2019/11/12 12:15
 end: 2019/11/12 12:50
+description: How to take advantage of fresh from the oven APIs as well as “classics” to create instant and seamless experiences, even when the network connection isn't cooperating.
 ---
 
 In this talk, we'll show you how to take advantage of fresh from the oven APIs as well as “classics” to create instant and seamless experiences, even when the network connection isn't cooperating. Join us to get up and running for the origin trials of Portals and Periodic Background Sync, find out the latest about Web Packaging and Content Indexing API, and get inspired by showcased experiences built with these technologies.

--- a/src/sessions/make-loading-disappear-with-portals.md
+++ b/src/sessions/make-loading-disappear-with-portals.md
@@ -9,7 +9,7 @@ speakers:
   - yusuke-utsunomiya
 start: 2019/11/12 12:15
 end: 2019/11/12 12:50
-description: How to take advantage of fresh from the oven APIs as well as “classics” to create instant and seamless experiences, even when the network connection isn't cooperating.
+description: How to take advantage of fresh from the oven APIs as well as “classics” to create instant and seamless experiences, even when the network connection isn't cooperating…
 ---
 
 In this talk, we'll show you how to take advantage of fresh from the oven APIs as well as “classics” to create instant and seamless experiences, even when the network connection isn't cooperating. Join us to get up and running for the origin trials of Portals and Periodic Background Sync, find out the latest about Web Packaging and Content Indexing API, and get inspired by showcased experiences built with these technologies.

--- a/src/sessions/next-generation-web-styling.md
+++ b/src/sessions/next-generation-web-styling.md
@@ -9,6 +9,7 @@ speakers:
   - una-kravets
 start: 2019/11/11 16:15
 end: 2019/11/11 16:50
+description: With new CSS features landing in browsers, and Houdini on the horizon, web styling has become so much more powerful than ever…
 ---
 
 With new CSS features landing in browsers, and Houdini on the horizon, web styling has become so much more powerful than ever. In this talk, we'll show you how to leverage these new properties and worklets to build fast, beautiful, and accessible websites.

--- a/src/sessions/protecting-users-on-a-working-web.md
+++ b/src/sessions/protecting-users-on-a-working-web.md
@@ -9,6 +9,7 @@ speakers:
   - michael-kleber
 start: 2019/11/11 11:00
 end: 2019/11/11 11:35
+description: New things Chrome is doing to create a secure environment for personalization that also protects user privacy and fights fingerprinting…
 ---
 
 To make safe decisions on the Web, we're asking users to understand increasingly complex concepts around their personal information and cross-site tracking. Chrome is improving its layers of protection across its Safe Browsing warnings including new warnings against deceptive Internationalized Domain Name along with providing the Suspicious Site Reporter extension allowing power users like web developers protect the masses from deceptive sites. Chrome is also adding new ways to ensure user privacy while still enabling a flourishing ecosystem for developers to build effective publishing businesses — a secure environment for personalization that also protects user privacy and fights fingerprinting. We're starting with proposed browser APIs to enable critical use cases like ad spam and fraud prevention and conversion measurement, bringing cutting-edge cryptographic and ML techniques to the web platform.

--- a/src/sessions/pwa-and-the-installable-web.md
+++ b/src/sessions/pwa-and-the-installable-web.md
@@ -8,6 +8,7 @@ speakers:
   - sam-thorogood
 start: 2019/11/11 16:50
 end: 2019/11/11 17:25
+description: This talk is for designers of enterprise & consumer web apps who want to understand the options for installed web experiences from browsers and the Play Store.
 ---
 
 The Web has a superpower—it's a frictionless and federated experience, whether for search results, news articles, ride sharing, or spreadsheets. With modern, evergreen browsers, your users can accept site prompts to install web experiences to their device's home screen or desktop.

--- a/src/sessions/pwa-and-the-installable-web.md
+++ b/src/sessions/pwa-and-the-installable-web.md
@@ -8,7 +8,7 @@ speakers:
   - sam-thorogood
 start: 2019/11/11 16:50
 end: 2019/11/11 17:25
-description: This talk is for designers of enterprise & consumer web apps who want to understand the options for installed web experiences from browsers and the Play Store.
+description: This talk is for designers of enterprise & consumer web apps who want to understand the options for installed web experiences from browsers and the Play Store…
 ---
 
 The Web has a superpower—it's a frictionless and federated experience, whether for search results, news articles, ride sharing, or spreadsheets. With modern, evergreen browsers, your users can accept site prompts to install web experiences to their device's home screen or desktop.

--- a/src/sessions/qa-with-chrome-leads.md
+++ b/src/sessions/qa-with-chrome-leads.md
@@ -5,7 +5,7 @@ topics:
   - Panel
 start: 2019/11/12 14:35
 end: 2019/11/12 15:10
-description: The leads of the Chrome team answer your questions.
+description: The leads of the Chrome team answer your questions…
 ---
 
 The leads of the Chrome team answer your questions.

--- a/src/sessions/qa-with-chrome-leads.md
+++ b/src/sessions/qa-with-chrome-leads.md
@@ -5,6 +5,7 @@ topics:
   - Panel
 start: 2019/11/12 14:35
 end: 2019/11/12 15:10
+description: The leads of the Chrome team answer your questions.
 ---
 
 The leads of the Chrome team answer your questions.

--- a/src/sessions/speed-tooling-evolutions.md
+++ b/src/sessions/speed-tooling-evolutions.md
@@ -9,7 +9,7 @@ speakers:
   - paul-irish
 start: 2019/11/11 12:50
 end: 2019/11/11 13:25
-description: Covering the newest user-centric metrics in our tools, and how to leverage Google and Chrome's newest features and products to build and maintain an exceptionally fast experience for all of your users.
+description: Covering the newest user-centric metrics in our tools, and how to leverage Google and Chrome's newest features and products to build and maintain an exceptionally fast experience for all of your users…
 ---
 
 Our understanding of how to accurately represent and optimize for a users' experience continues to grow more accurate and informed. Our speed metrics, automation story, and best-practice recommendations are kept up to date to reflect these learnings. This talk covers the newest user-centric metrics in our tools, and how to leverage Google and Chrome's newest features and products to build and maintain an exceptionally fast experience for all of your users.

--- a/src/sessions/speed-tooling-evolutions.md
+++ b/src/sessions/speed-tooling-evolutions.md
@@ -9,6 +9,7 @@ speakers:
   - paul-irish
 start: 2019/11/11 12:50
 end: 2019/11/11 13:25
+description: Covering the newest user-centric metrics in our tools, and how to leverage Google and Chrome's newest features and products to build and maintain an exceptionally fast experience for all of your users.
 ---
 
 Our understanding of how to accurately represent and optimize for a users' experience continues to grow more accurate and informed. Our speed metrics, automation story, and best-practice recommendations are kept up to date to reflect these learnings. This talk covers the newest user-centric metrics in our tools, and how to leverage Google and Chrome's newest features and products to build and maintain an exceptionally fast experience for all of your users.

--- a/src/sessions/the-main-thread-is-a-bad-place-to-run-your-code.md
+++ b/src/sessions/the-main-thread-is-a-bad-place-to-run-your-code.md
@@ -7,6 +7,7 @@ speakers:
   - surma
 start: 2019/11/11 15:10
 end: 2019/11/11 15:45
+description: How can we make sure our experience is great for everyone? What do we need to change in our web development process to be more accommodating to hyper-constrained devices? The answer is architecture…
 ---
 
 Amongst all the platforms for app development, the web is arguably the only one that does not make use of threading. On the web the main thread is already overworked, and the median phone is not getting faster.

--- a/src/sessions/the-things-youll-compile.md
+++ b/src/sessions/the-things-youll-compile.md
@@ -8,7 +8,7 @@ speakers:
   - ingvar-stepanyan
 start: 2019/11/12 12:50
 end: 2019/11/12 13:25
-description: How you can use WebAssembly in new ways, learn from real-world sites that are shipping WebAssembly, and see some of the exciting upcoming features.
+description: How you can use WebAssembly in new ways, learn from real-world sites that are shipping WebAssembly, and see some of the exciting upcoming features…
 ---
 
 WebAssembly is an entirely new language format for the Web that lets you run languages that were previously impossible on the Web. Come to this talk to see how you can use WebAssembly in new ways, learn from real-world sites that are shipping WebAssembly, and see some of the exciting upcoming features.

--- a/src/sessions/the-things-youll-compile.md
+++ b/src/sessions/the-things-youll-compile.md
@@ -8,6 +8,7 @@ speakers:
   - ingvar-stepanyan
 start: 2019/11/12 12:50
 end: 2019/11/12 13:25
+description: How you can use WebAssembly in new ways, learn from real-world sites that are shipping WebAssembly, and see some of the exciting upcoming features.
 ---
 
-WebAssembly is an entirely new language format for the Web that lets you run languages that were previously impossible on the Web. In this talk, Come to this talk to see how you can use WebAssembly in new ways, learn from real-world sites that are shipping WebAssembly, and see some of the exciting upcoming features.
+WebAssembly is an entirely new language format for the Web that lets you run languages that were previously impossible on the Web. Come to this talk to see how you can use WebAssembly in new ways, learn from real-world sites that are shipping WebAssembly, and see some of the exciting upcoming features.

--- a/src/sessions/web-as-a-building-block-for-ux.md
+++ b/src/sessions/web-as-a-building-block-for-ux.md
@@ -7,7 +7,7 @@ speakers:
   - dev-gogate
 start: 2019/11/12 15:10
 end: 2019/11/12 15:45
-description: Learn how the Web provides the connection for emerging technologies and how to leverage the many superpowers of the Web to build engaging experiences for your users that span surfaces and input modalities.
+description: Learn how the Web provides the connection for emerging technologies and how to leverage the many superpowers of the Web to build engaging experiences for your users that span surfaces and input modalities…
 ---
 
 A user's journey on mobile is not linear and does not necessarily start and end with the browser. Learn how the Web provides the connection for emerging technologies and how to leverage the many superpowers of the Web to build engaging experiences for your users that span surfaces and input modalities.

--- a/src/sessions/web-as-a-building-block-for-ux.md
+++ b/src/sessions/web-as-a-building-block-for-ux.md
@@ -7,6 +7,7 @@ speakers:
   - dev-gogate
 start: 2019/11/12 15:10
 end: 2019/11/12 15:45
+description: Learn how the Web provides the connection for emerging technologies and how to leverage the many superpowers of the Web to build engaging experiences for your users that span surfaces and input modalities.
 ---
 
 A user's journey on mobile is not linear and does not necessarily start and end with the browser. Learn how the Web provides the connection for emerging technologies and how to leverage the many superpowers of the Web to build engaging experiences for your users that span surfaces and input modalities.

--- a/src/sessions/whats-new-in-sign-up-and-sign-in.md
+++ b/src/sessions/whats-new-in-sign-up-and-sign-in.md
@@ -7,6 +7,7 @@ speakers:
   - eiji-kitamura
 start: 2019/11/11 12:15
 end: 2019/11/11 12:50
+description: In this talk we'll describe an effective way for users to sign up to your website, and sign back in more easily and safely using second factor leveraging SMS or biometric information.
 ---
 
 The Web is becoming more capable of signing up and signing in users securely and seamlessly. In this talk we'll describe an effective way for users to sign up to your website, and sign back in more easily and safely using second factor leveraging SMS or biometric information. We'll also cover how these methods work in the real world.

--- a/src/sessions/whats-new-in-sign-up-and-sign-in.md
+++ b/src/sessions/whats-new-in-sign-up-and-sign-in.md
@@ -7,7 +7,7 @@ speakers:
   - eiji-kitamura
 start: 2019/11/11 12:15
 end: 2019/11/11 12:50
-description: In this talk we'll describe an effective way for users to sign up to your website, and sign back in more easily and safely using second factor leveraging SMS or biometric information.
+description: In this talk we'll describe an effective way for users to sign up to your website, and sign back in more easily and safely using second factor leveraging SMS or biometric information…
 ---
 
 The Web is becoming more capable of signing up and signing in users securely and seamlessly. In this talk we'll describe an effective way for users to sign up to your website, and sign back in more easily and safely using second factor leveraging SMS or biometric information. We'll also cover how these methods work in the real world.


### PR DESCRIPTION
I experimented with a auto automated ways to truncate talk descriptions (omg `line-clamp` is so so buggy), then I thought noooope, better to do it manually.