### PR TITLE
shift header and it's boxed content to adapt at 1024 instead of 1280

### DIFF
--- a/src/_includes/page.css
+++ b/src/_includes/page.css
@@ -2,7 +2,7 @@
   background: var(--offwhite);
   padding: 3rem var(--side-margin) 0;
 
-  @media (min-width: 1280px) {
+  @media (min-width: 1024px) {
     padding: 8rem var(--side-margin) 2rem;
     min-height: 11rem;
     display: grid;
@@ -44,7 +44,7 @@
     margin-bottom: 0;
   }
 
-  @media (min-width: 1280px) {
+  @media (min-width: 1024px) {
     margin: 0;
     background: var(--white);
     padding: 1.6rem 1.8rem;


### PR DESCRIPTION
this fixes medium sized laptops from seeing a single column styles header, which is better for tablet than smallerish laptops

aka: my pixelbook is seeing a full width description in the header when it's got plenty of room for the boxed content on the right