### PR TITLE
Increase main navigation link padding

### DIFF
--- a/src/_includes/header/style.css
+++ b/src/_includes/header/style.css
@@ -140,6 +140,7 @@
     line-height: normal;
     font-size: 0.8em;
     margin: 0.5em 0.55em;
+    padding: 1em 0;
 
     @media (min-width: 320px) {
       margin: 0.5em 0.7em;


### PR DESCRIPTION
This increases the clickable/tappable area for the main navigation links. There is no visible difference, other than that a larger vertical area can now be clicked/tapped.

Before (outline added for clarity):

![Screenshot from 2019-10-25 11-31-52](https://user-images.githubusercontent.com/81942/67560565-6e680800-f71b-11e9-9f96-68a48a0a74fc.png)

After:

![Screenshot from 2019-10-25 11-31-17](https://user-images.githubusercontent.com/81942/67560560-6c9e4480-f71b-11e9-86cd-69c286a6095b.png)

