### PR TITLE
Make `npm start` and `npm run serve` work for everyone

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "2019.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./server.js",
+    "start": "npm run serve",
     "build": "npm run clean && rollup -c && del .build-tmp",
     "watch": "npm run clean && rollup -c --watch",
     "clean": "del build .build-tmp",
     "deploy": "npm run build && firebase deploy",
-    "serve": "firebase serve --only hosting"
+    "serve": "superstatic --only hosting"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.9.0",
@@ -34,7 +34,8 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-terser": "^5.1.2"
+    "rollup-plugin-terser": "^5.1.2",
+    "superstatic": "^6.0.4"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fixes the two issues outlined here: https://github.com/GoogleChrome/devsummit/pull/333#issuecomment-546282960