### PR TITLE
[Without `timezonechange` polyfill] Re-render the schedule when the timezone changes

### DIFF
--- a/src/_includes/timezone-toggle/index.njk
+++ b/src/_includes/timezone-toggle/index.njk
@@ -20,7 +20,12 @@
     {
       const form = document.currentScript.previousElementSibling;
       import('confboxAsset(/_includes/timezone-toggle/script/index.js)').then(
-        ({ enhance }) => enhance(form)
+        ({ enhance }) => {
+          enhance(form);
+          window.addEventListener('timezonechange', () => {
+            enhance(form);
+          });
+        }
       );
     }
   </script>

--- a/src/_includes/timezone-toggle/script/option.js
+++ b/src/_includes/timezone-toggle/script/option.js
@@ -18,7 +18,11 @@ export function onChange(func) {
   eventTarget.addEventListener(eventName, func);
 }
 
-export const localOffset = new Date().getTimezoneOffset() * 60 * 1000 * -1;
+export let localOffset = new Date().getTimezoneOffset() * 60 * 1000 * -1;
+
+window.addEventListener('timezonechange', () => {
+  localOffset = new Date().getTimezoneOffset() * 60 * 1000 * -1;
+});
 
 window.addEventListener('storage', () => {
   set(localStorage.timezoneOption);

--- a/src/schedule/script/index.js
+++ b/src/schedule/script/index.js
@@ -22,6 +22,10 @@ function render() {
 
 onChange(render);
 
+window.addEventListener('timezonechange', () => {
+  render();
+});
+
 if (getTimezoneOption() === 'local') {
   render();
   el.style.visibility = 'visible';


### PR DESCRIPTION
This patch leverages the `timezonechange` event (https://github.com/whatwg/html/pull/3047) to dynamically re-render the schedule when the timezone changes. 

With this patch the new functionality will automatically start working once browsers start shipping support for the new event.

Same patch but with an added polyfill: #335.