### PR TITLE
Print schedule

### DIFF
--- a/src/schedule/index.njk
+++ b/src/schedule/index.njk
@@ -101,4 +101,7 @@ description: Everything that's happening at Chrome Dev Summit.
   {% include 'subscribe-promo/index.njk' %}
   {% from 'squiggle-banner/index.njk' import squiggleBanner %}
   {{ squiggleBanner(page, '--red') }}
+
+  <link rel="stylesheet" media="print" href="confboxAsset(/schedule/print.css)">
+
 {% endblock %}

--- a/src/schedule/print.css
+++ b/src/schedule/print.css
@@ -1,0 +1,39 @@
+@page {
+  margin: 2cm;
+  size: 8.5in 11in;
+}
+
+body {
+  zoom: 0.8;
+}
+
+[class*='day'] > [class*='date'],
+[class*='day'] [class*='day-number'] {
+  background-color: #1a73e8;
+}
+
+[class*='meta'],
+[class*='time-line'] {
+  break-inside: avoid;
+}
+
+[class*='header'],
+[class*='root'] {
+  display: none !important;
+}
+
+a,
+[class*='button'],
+[class*='get-updates'],
+[class*='item'],
+[class*='boxed-content'] {
+  box-shadow: none;
+}
+
+[class*='header'],
+[class*='schedule'],
+[class*='topic'],
+[class*='time'],
+[class*='overflow'] {
+  background-color: transparent;
+}


### PR DESCRIPTION
Fixes #245

give it a test would ya? [try printing the schedule page](https://deploy-preview-343--cds2019.netlify.com/devsummit/schedule/)

- [x] I'd like to debug why page breaks arent being avoided? would like no awkward sessions to break.