### PR TITLE
Set missing alt img attributes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,6 +30,7 @@ function buildScheduleData(sessions, speakers, { basic = false } = {}) {
       if (!basic) {
         obj.topics = session.data.topics;
         obj.avatar = session.data.avatar;
+        obj.avatarDescription = session.data.avatar_description || '';
         obj.body = session.data.description;
       }
 

--- a/src/schedule/script/create-schedule.js
+++ b/src/schedule/script/create-schedule.js
@@ -59,7 +59,10 @@ module.exports = function createScheduleHtml(
                       ? html`
                           <div class="${classNameMap.iconBubble}">
                             <div class="${classNameMap.avatars}">
-                              <img src="${item.avatar}" alt="" />
+                              <img
+                                src="${item.avatar}"
+                                alt="${item.avatarDescription}"
+                              />
                             </div>
                           </div>
                         `

--- a/src/schedule/script/create-workshops.js
+++ b/src/schedule/script/create-workshops.js
@@ -21,6 +21,7 @@ module.exports = function createWorkshopHtml(items, utcOffset, classNameMap) {
                 <img
                   class="${classNameMap.workshopAvatar}"
                   src="${item.speakers[0].avatar}"
+                  alt="${item.speakers[0].name}"
                   decoding="async"
                   loading="lazy"
                 />

--- a/src/sessions/chrome-and-the-web-in-2020.md
+++ b/src/sessions/chrome-and-the-web-in-2020.md
@@ -13,6 +13,7 @@ start: 2020/12/09 09:30
 end: 2020/12/09 10:15
 description: It's the keynote! We will take you through some of the latest announcements and helpful updates to the platform, and talk about tools that help you build high-quality web experiences even more effectively.
 avatar: /schedule/assets/bendion.jpg
+avatar_description: Ben and Dion
 ---
 
 Join us for the opening keynote of the first ever virtual Chrome Dev Summit where we'll have Googlers, community members, and our partners come together to share our vision for the Web. We will take you through some of the latest announcements and helpful updates to the platform, and talk about tools that help you build high-quality web experiences even more effectively.


### PR DESCRIPTION
This PR is about adding missing `alt` img attributes raised by Lighthouse audit. 

![image](https://user-images.githubusercontent.com/634478/98356552-0afa0100-2024-11eb-9590-f43241f8ea95.png)
