### PR TITLE
Switch to larger font-size later

### DIFF
--- a/src/_includes/layouts/main/style.css
+++ b/src/_includes/layouts/main/style.css
@@ -17,7 +17,7 @@ html {
     font-size: 17px;
   }
 
-  @media (min-width: 1440px) {
+  @media (min-width: 1600px) {
     font-size: 21px;
   }
 }


### PR DESCRIPTION
We've had a request to make the entire hero appear above the fold on devices around the 1400x820 mark. (don't have exact resolution) Currently, with the lengthier hero copy, the LHS surpasses the bottom of the screen and as a result the vertically centered image does too.  Increasing to 21px at larger dimensions fixes this.